### PR TITLE
whitelistedTokens

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -201,9 +201,11 @@ export class AdViewManager {
 							return {}
 						}
 					})
-				// This object is a mapping of tokenAddr->value, so this is a hack right now
-				// @TODO fix it
-				const resMinPerImpression: any = Object.values(resSlot.minPerImpression || {})[0]
+				// If this is an object, it is a mapping of tokenAddr->value, but since a slot always uses tokens
+				// of the same price/decimals, all values should be the same
+				const resMinPerImpression: any = typeof resSlot.minPerImpression === 'string'
+					? resSlot.minPerImpression
+					: Object.values(resSlot.minPerImpression || {})[0]
 				const optsOverride = {
 					fallbackUnit: resSlot.fallbackUnit || opts.fallbackUnit,
 					minPerImpression: resMinPerImpression || opts.minPerImpression,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@ const defaultOpts = {
 	acceptedStates: ['Active', 'Ready'],
 	minPerImpression: '1',
 	minTargetingScore: 0,
+	// SAI and DAI
+	whitelistedTokens: ['0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359', '0x6B175474E89094C44Da98b954EedeAC495271d0F'],
 	topByPrice: 10,
 	topByScore: 5,
 	randomize: true,
@@ -28,7 +30,9 @@ interface AdViewManagerOptions {
 	randomize: boolean,
 	// Must be passed (except the ones with ?)
 	publisherAddr: string,
-	whitelistedToken: string,
+	// All passed tokens must be of the same price and decimals, so that the amounts can be accurately compared
+	// e.g. SAI and DAI
+	whitelistedTokens?: Array<string>,
 	whitelistedType?: string,
 	topByPrice?: number,
 	topByScore?: number,
@@ -55,7 +59,7 @@ export function applySelection(campaigns: Array<any>, options: AdViewManagerOpti
 		return options.acceptedStates.includes(campaign.status.name)
 			&& (campaign.spec.activeFrom || 0) < Date.now()
 			&& Array.isArray(campaign.spec.adUnits)
-			&& campaign.depositAsset === options.whitelistedToken
+			&& options.whitelistedTokens.includes(campaign.depositAsset)
 			&& new BN(campaign.spec.minPerImpression)
 				.gte(new BN(options.minPerImpression))
 	})
@@ -197,7 +201,9 @@ export class AdViewManager {
 							return {}
 						}
 					})
-				const resMinPerImpression = (resSlot.minPerImpression || {})[opts.whitelistedToken]
+				// This object is a mapping of tokenAddr->value, so this is a hack right now
+				// @TODO fix it
+				const resMinPerImpression: any = Object.values(resSlot.minPerImpression || {})[0]
 				const optsOverride = {
 					fallbackUnit: resSlot.fallbackUnit || opts.fallbackUnit,
 					minPerImpression: resMinPerImpression || opts.minPerImpression,

--- a/test/src.test.ts
+++ b/test/src.test.ts
@@ -78,7 +78,7 @@ const options = {
 	minPerImpression: new BN(1),
 	minTargetingScore: 0,
 	randomize: true,
-	whitelistedToken
+	whitelistedTokens: [whitelistedToken],
 }
 
 const optionsWithTopByPrice = {


### PR DESCRIPTION
allow multiple whitelisted tokens, of the same price ande decimals

Currently, there's a problem: when loading an ad slot from the market, `slot.minPerImpression` is by token, but we don't know the token until later, when we have an array of campaigns (each campaign has a `depositAsset`)

so... we should either refactor the code to allow for this or find another solution; https://github.com/AdExNetwork/adex-platform/pull/277 is related, since there we must decide how to set the same `slot.minPerImpression`

If each slot has a particular `whitelistedTokens`, which are of the same price and decimals, then we only need one value of `minPerImpression`