### PR TITLE
getHTML: pass adSlot to the validators

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -163,7 +163,8 @@ function getUnitHTML({ width, height }: AdViewManagerOptions, { unit, onLoadCode
 }
 
 export function getHTML(options: AdViewManagerOptions, { unit, channelId, validators }): string {
-	const getBody = (evType) => `JSON.stringify({ events: [{ type: '${evType}', publisher: '${options.publisherAddr}', adUnit: '${unit.ipfs}', ref: document.referrer }] })`
+	const adSlotCode = options.marketSlot ? `, adSlot: '${options.marketSlot}'` : ''
+	const getBody = (evType) => `JSON.stringify({ events: [{ type: '${evType}', publisher: '${options.publisherAddr}', adUnit: '${unit.ipfs}', ref: document.referrer${adSlotCode} }] })`
 	const getCode = (evType) => `var fetchOpts = { method: 'POST', headers: { 'content-type': 'application/json' }, body: ${getBody(evType)} };` + validators
 		.map(({ url }) => {
 			const fetchUrl = `${url}/channel/${channelId}/events`


### PR DESCRIPTION
Passes `adSlot` so that the validators can record it's ID

**WARNING**: requires merging https://github.com/AdExNetwork/adex-validator/pull/247 first