### PR TITLE
respect aspectReferrers

### DIFF
--- a/main-browser.js
+++ b/main-browser.js
@@ -38,10 +38,17 @@ function initWithOptions(options) {
 	}
 	const mgr = new AdViewManager((url, o) => fetch(url, o), options)
 	mgr.getNextAdUnit().then(u => {
+		if (Array.isArray(mgr.options.acceptedReferrers)
+			&& document.referrer
+			&& !mgr.options.acceptedReferrers.some(ref => document.referrer.startsWith(ref))
+		) {
+			console.log(`AdEx: ad slot installed on wrong website (referrer)`)
+			collapse()
+			return
+		}
 		if (u) {
 			document.body.innerHTML = u.html
-		}
-		if (!u) {
+		} else {
 			console.log(`AdEx: no ad demand for slot (${options.type})`)
 		}
 		if (window.parent) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-adview-manager",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-adview-manager",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "AdEx Adview manager library",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
if the slot is limited to particular referrers, respect that

Solves #53 

However, there are two remaining things:

- [x] research if `document.referrer` is the best way to find iframe parent origin; seems to be OK: https://stackoverflow.com/a/7739035 ; although it will fail if the AdView iframe navigates itself, but this cannot happen; other caveats: (referer-policy header, running on localhost/file:///)
- [x] keep in mind that we've currently allowed running with no `document.referrer`