### PR TITLE
rules: UndefinedVar error on set

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -189,6 +189,8 @@ export function evaluate(input: any, output: any, rule: any) {
 		assertArrayArgs(rule.set, 2)
 		const key = assertType(rule.set[0], 'string')
 		const prevType = getTypeName(output[key])
+		if (prevType === 'undefined')
+			throw new RuleEvalError({ message: `UndefinedVar: ${key}`, undefinedVar: key })
 		const value = evalRule(rule.set[1])
 		output[key] = assertType(value, prevType)
 	// utilities

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -160,6 +160,7 @@ test('strings', t => {
 // set/get
 test('set/get: errors', t => {
 	t.throws(() => evaluate({}, {}, { get: 'somevar' }), RuleEvalError, 'undefined variable error')
+	t.throws(() => evaluate({}, {}, { set: ['somevar', 0] }), RuleEvalError, 'undefined variable error')
 	t.throws(() => evalToOutput({ set: ['foo', 'string'] }), RuleEvalError, 'cannot change type of an output variable')
 	t.end()
 })


### PR DESCRIPTION
solves the following validator error
```
	sentry: WARNING: rule for 0xc892b8def2c6077504642390609a55283854ab05d55b31e585088d4f16b5e833 failing with: TypeError: expected 1000000000000000 to be of type undefined; rule {"if":[{"in":[["AR","CL","ES","VE"],{"get":"country"}]},{"set":["price.IMPRESSION",{"bn":"1000000000000000"}]}]}
```

which happens on click